### PR TITLE
story(otel): fix otel gcp publishing batchwritespans traces

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/z5labs/bedrock/pkg/otelconfig"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // ManageOTel is a hook for intializing OTel on PreBuild and shutting it down on PostRun.
@@ -27,6 +28,8 @@ func ManageOTel(f func(context.Context) (otelconfig.Initializer, error)) func(*b
 				return err
 			}
 			otel.SetTracerProvider(tp)
+			// need to set this so traces can propagate
+			otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 			return nil
 		})
 

--- a/pkg/otelconfig/gcp.go
+++ b/pkg/otelconfig/gcp.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/api/option"
 )
 
 // GoogleCloudConfig is the config for the Google Cloud Initializer.
@@ -51,7 +52,10 @@ func GoogleCloud(opts ...GoogleCloudOption) Initializer {
 
 // Init implements the Initializer interface.
 func (cfg GoogleCloudConfig) Init() (trace.TracerProvider, error) {
-	exporter, err := texporter.New(texporter.WithProjectID(cfg.ProjectId))
+	exporter, err := texporter.New(
+		texporter.WithProjectID(cfg.ProjectId),
+		texporter.WithTraceClientOptions([]option.ClientOption{option.WithTelemetryDisabled()}),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -68,13 +72,6 @@ func (cfg GoogleCloudConfig) Init() (trace.TracerProvider, error) {
 		}
 	}
 
-	// Create trace provider with the exporter.
-	//
-	// By default it uses AlwaysSample() which samples all traces.
-	// In a production environment or high QPS setup please use
-	// probabilistic sampling.
-	// Example:
-	//   tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.TraceIDRatioBased(0.0001)), ...)
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),


### PR DESCRIPTION
changes:
- added option to texporter init to disable tracing the underlying trace code
- removed comment copied from gcp docs page

closes #178 