### PR TITLE
story(issue-246): consume interface instead of endpoint.Endpoint directly in option

### DIFF
--- a/example/simple_rest/app/app.go
+++ b/example/simple_rest/app/app.go
@@ -39,7 +39,8 @@ func Init(ctx context.Context, cfg Config) (bedrock.App, error) {
 
 	restApp := rest.NewApp(
 		rest.ListenOn(cfg.Http.Port),
-		rest.Endpoint(
+		rest.Handle(
+			"/echo",
 			endpoint.Post(
 				"/echo",
 				echoService,

--- a/rest/rest_example_test.go
+++ b/rest/rest_example_test.go
@@ -73,7 +73,8 @@ func Example() {
 
 	app := NewApp(
 		listenOnRandomPort(addrCh),
-		Endpoint(
+		Handle(
+			"/",
 			endpoint.Post(
 				"/",
 				echoService{},


### PR DESCRIPTION
Closes #246 