### PR TITLE
story(issue-285): rest use http method in http.ServeMux pattern when registering endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 [![Go Reference](https://pkg.go.dev/badge/github.com/z5labs/bedrock.svg)](https://pkg.go.dev/github.com/z5labs/bedrock)
 [![Go Report Card](https://goreportcard.com/badge/github.com/z5labs/bedrock)](https://goreportcard.com/report/github.com/z5labs/bedrock)
-![Coverage](https://img.shields.io/badge/Coverage-96.5%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-96.6%25-brightgreen)
 [![build](https://github.com/z5labs/bedrock/actions/workflows/build.yaml/badge.svg)](https://github.com/z5labs/bedrock/actions/workflows/build.yaml)
 
 **bedrock provides a minimal, modular and composable foundation for

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -6,13 +6,13 @@
 package rest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
+	"slices"
+	"strings"
 
 	"github.com/swaggest/openapi-go/openapi3"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -43,17 +43,54 @@ type Operation interface {
 
 // Endpoint registers the [Operation] with both
 // the App wide OpenAPI spec and the App wide HTTP server.
+//
+// "/" is always treated as "/{$}" because it would otherwise
+// match too broadly and cause conflicts with other paths.
 func Endpoint(method, pattern string, op Operation) Option {
 	return func(app *App) {
-		err := app.spec.AddOperation(method, pattern, op.OpenApi())
+		// Per the net/http.ServeMux docs, https://pkg.go.dev/net/http#ServeMux:
+		//
+		// 		The special wildcard {$} matches only the end of the URL.
+		//      For example, the pattern "/{$}" matches only the path "/",
+		//      whereas the pattern "/" matches every path.
+		//
+		// This means that when registering the pattern with the OpenAPI spec
+		// the {$} needs to be stripped because OpenAPI will believe it's
+		// an actual path parameter.
+		trimmedPattern := strings.TrimRight(pattern, "{$}")
+		err := app.spec.AddOperation(method, trimmedPattern, op.OpenApi())
 		if err != nil {
 			panic(err)
 		}
 
+		// enforce strict matching for top-level path
+		// otherwise "/" would match too broadly and http.ServeMux
+		// will panic when other paths are registered e.g. /openapi.json
+		if pattern == "/" {
+			pattern = "/{$}"
+		}
+		app.pathMethods[pattern] = append(app.pathMethods[pattern], method)
+
 		app.mux.Handle(
-			pattern,
-			otelhttp.WithRouteTag(pattern, op),
+			fmt.Sprintf("%s %s", method, pattern),
+			otelhttp.WithRouteTag(trimmedPattern, op),
 		)
+	}
+}
+
+// NotFoundHandler will register the given [http.Handler] to handle
+// any HTTP requests that do not match any other method-pattern combinations.
+func NotFoundHandler(h http.Handler) Option {
+	return func(app *App) {
+		app.mux.Handle("/{path...}", h)
+	}
+}
+
+// MethodNotAllowedHandler will register the given [http.Handler] to handle
+// any HTTP requests whose method does not match the method registered to a pattern.
+func MethodNotAllowedHandler(h http.Handler) Option {
+	return func(app *App) {
+		app.methodNotAllowedHandler = h
 	}
 }
 
@@ -84,6 +121,9 @@ type App struct {
 	spec *openapi3.Spec
 	mux  *http.ServeMux
 
+	pathMethods             map[string][]string
+	methodNotAllowedHandler http.Handler
+
 	listen      func(network, addr string) (net.Listener, error)
 	marshalJSON func(any) ([]byte, error)
 }
@@ -96,6 +136,7 @@ func NewApp(opts ...Option) *App {
 			Openapi: "3.0.3",
 		},
 		mux:         http.NewServeMux(),
+		pathMethods: make(map[string][]string),
 		listen:      net.Listen,
 		marshalJSON: json.Marshal,
 	}
@@ -107,13 +148,14 @@ func NewApp(opts ...Option) *App {
 
 // Run implements the [bedrock.App] interface.
 func (app *App) Run(ctx context.Context) error {
-	spec, err := app.marshalJSON(app.spec)
-	if err != nil {
-		return err
-	}
-	app.mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.Copy(w, bytes.NewReader(spec))
-	})
+	app.mux.Handle(
+		fmt.Sprintf("%s %s", http.MethodGet, "/openapi.json"),
+		openApiHandler{
+			spec: app.spec,
+		},
+	)
+
+	app.registerMethodNotAllowedHandler()
 
 	ls, err := app.listen("tcp", fmt.Sprintf(":%d", app.port))
 	if err != nil {
@@ -145,4 +187,49 @@ func (app *App) Run(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+type openApiHandler struct {
+	spec *openapi3.Spec
+}
+
+func (h openApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	enc := json.NewEncoder(w)
+	enc.Encode(h.spec)
+}
+
+func (app *App) registerMethodNotAllowedHandler() {
+	if app.methodNotAllowedHandler == nil {
+		return
+	}
+
+	// this list is pulled from the OpenAPI v3 Path Item Object documentation.
+	supportedMethods := []string{
+		http.MethodGet,
+		http.MethodPut,
+		http.MethodPost,
+		http.MethodDelete,
+		http.MethodOptions,
+		http.MethodHead,
+		http.MethodPatch,
+		http.MethodTrace,
+	}
+
+	for path, methods := range app.pathMethods {
+		unsupportedMethods := diffSets(supportedMethods, methods)
+		for _, method := range unsupportedMethods {
+			app.mux.Handle(fmt.Sprintf("%s %s", method, path), app.methodNotAllowedHandler)
+		}
+	}
+}
+
+func diffSets(xs, ys []string) []string {
+	zs := make([]string, 0, len(xs))
+	for _, x := range xs {
+		if slices.Contains(ys, x) {
+			continue
+		}
+		zs = append(zs, x)
+	}
+	return zs
 }

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -195,7 +195,7 @@ type openApiHandler struct {
 
 func (h openApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
-	enc.Encode(h.spec)
+	_ = enc.Encode(h.spec)
 }
 
 func (app *App) registerMethodNotAllowedHandler() {

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -13,12 +13,305 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/swaggest/openapi-go/openapi3"
 	"golang.org/x/sync/errgroup"
 )
+
+type statusCodeHandler int
+
+func (h statusCodeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(int(h))
+}
+
+func (h statusCodeHandler) OpenApi() openapi3.Operation {
+	return openapi3.Operation{}
+}
+
+func TestNotFoundHandler(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		RegisterPattern string
+		RequestPath     string
+		NotFound        bool
+	}{
+		{
+			Name:        "should match not found if no other endpoints are registered and '/' is requested",
+			RequestPath: "/",
+			NotFound:    true,
+		},
+		{
+			Name:        "should match not found if no other endpoints are registered and a sub path is requested",
+			RequestPath: "/hello",
+			NotFound:    true,
+		},
+		{
+			Name:            "should match not found if other endpoints are registered and '/' is requested",
+			RegisterPattern: "/hello",
+			RequestPath:     "/",
+			NotFound:        true,
+		},
+		{
+			Name:            "should match not found if other endpoints are registered and unknown sub-path is requested",
+			RegisterPattern: "/hello",
+			RequestPath:     "/bye",
+			NotFound:        true,
+		},
+		{
+			Name:            "should match not found if '/{$}' is registered and a sub-path is requested",
+			RegisterPattern: "/{$}",
+			RequestPath:     "/bye",
+			NotFound:        true,
+		},
+		{
+			Name:            "should not match not found if endpoint pattern is requested",
+			RegisterPattern: "/hello",
+			RequestPath:     "/hello",
+			NotFound:        false,
+		},
+		{
+			Name:            "should not match not found if '/{$}' is registered and '/' requested",
+			RegisterPattern: "/{$}",
+			RequestPath:     "/",
+			NotFound:        false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			notFoundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+
+				enc := json.NewEncoder(w)
+				enc.Encode(map[string]any{"hello": "world"})
+			})
+
+			addrCh := make(chan net.Addr)
+			app := NewApp(
+				func(a *App) {
+					a.listen = func(network, addr string) (net.Listener, error) {
+						ls, err := net.Listen(network, ":0")
+						if err != nil {
+							return nil, err
+						}
+						defer close(addrCh)
+
+						addrCh <- ls.Addr()
+						return ls, nil
+					}
+				},
+				func(a *App) {
+					if testCase.RegisterPattern == "" {
+						return
+					}
+					Endpoint(http.MethodGet, testCase.RegisterPattern, statusCodeHandler(http.StatusOK))(a)
+				},
+				NotFoundHandler(notFoundHandler),
+			)
+
+			respCh := make(chan *http.Response, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			eg, egctx := errgroup.WithContext(ctx)
+			eg.Go(func() error {
+				return app.Run(egctx)
+			})
+			eg.Go(func() error {
+				defer cancel()
+				defer close(respCh)
+
+				addr := <-addrCh
+				url := fmt.Sprintf("http://%s", path.Join(addr.String(), testCase.RequestPath))
+				resp, err := http.Get(url)
+				if err != nil {
+					return err
+				}
+
+				select {
+				case <-egctx.Done():
+					return egctx.Err()
+				case respCh <- resp:
+				}
+				return nil
+			})
+
+			err := eg.Wait()
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			resp := <-respCh
+			if !assert.NotNil(t, resp) {
+				return
+			}
+			if !testCase.NotFound {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				return
+			}
+			if !assert.Equal(t, http.StatusNotFound, resp.StatusCode) {
+				return
+			}
+			defer resp.Body.Close()
+
+			b, err := io.ReadAll(resp.Body)
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			var m map[string]any
+			err = json.Unmarshal(b, &m)
+			if !assert.Nil(t, err) {
+				return
+			}
+			if !assert.Contains(t, m, "hello") {
+				return
+			}
+			if !assert.Equal(t, "world", m["hello"]) {
+				return
+			}
+		})
+	}
+}
+
+func TestMethodNotAllowedHandler(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		RegisterPatterns map[string]string
+		Method           string
+		RequestPath      string
+		MethodNotAllowed bool
+	}{
+		{
+			Name: "should return success response when correct method is used",
+			RegisterPatterns: map[string]string{
+				http.MethodGet: "/",
+			},
+			Method:           http.MethodGet,
+			RequestPath:      "/",
+			MethodNotAllowed: false,
+		},
+		{
+			Name: "should return success response when more than one method is registered for same path",
+			RegisterPatterns: map[string]string{
+				http.MethodGet:  "/",
+				http.MethodPost: "/",
+			},
+			Method:           http.MethodGet,
+			RequestPath:      "/",
+			MethodNotAllowed: false,
+		},
+		{
+			Name: "should return method not allowed response when incorrect method is used",
+			RegisterPatterns: map[string]string{
+				http.MethodGet: "/",
+			},
+			Method:           http.MethodPost,
+			RequestPath:      "/",
+			MethodNotAllowed: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			methodNotAllowedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+
+				enc := json.NewEncoder(w)
+				enc.Encode(map[string]any{"hello": "world"})
+			})
+
+			addrCh := make(chan net.Addr)
+			app := NewApp(
+				func(a *App) {
+					a.listen = func(network, addr string) (net.Listener, error) {
+						ls, err := net.Listen(network, ":0")
+						if err != nil {
+							return nil, err
+						}
+						defer close(addrCh)
+
+						addrCh <- ls.Addr()
+						return ls, nil
+					}
+				},
+				func(a *App) {
+					for method, pattern := range testCase.RegisterPatterns {
+						Endpoint(method, pattern, statusCodeHandler(http.StatusOK))(a)
+					}
+				},
+				MethodNotAllowedHandler(methodNotAllowedHandler),
+			)
+
+			respCh := make(chan *http.Response, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			eg, egctx := errgroup.WithContext(ctx)
+			eg.Go(func() error {
+				return app.Run(egctx)
+			})
+			eg.Go(func() error {
+				defer cancel()
+				defer close(respCh)
+
+				addr := <-addrCh
+				url := fmt.Sprintf("http://%s", path.Join(addr.String(), testCase.RequestPath))
+
+				req, err := http.NewRequestWithContext(egctx, testCase.Method, url, nil)
+				if err != nil {
+					return err
+				}
+
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					return err
+				}
+
+				select {
+				case <-egctx.Done():
+					return egctx.Err()
+				case respCh <- resp:
+				}
+				return nil
+			})
+
+			err := eg.Wait()
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			resp := <-respCh
+			if !assert.NotNil(t, resp) {
+				return
+			}
+			if !testCase.MethodNotAllowed {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				return
+			}
+			if !assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode) {
+				return
+			}
+			defer resp.Body.Close()
+
+			b, err := io.ReadAll(resp.Body)
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			var m map[string]any
+			err = json.Unmarshal(b, &m)
+			if !assert.Nil(t, err) {
+				return
+			}
+			if !assert.Contains(t, m, "hello") {
+				return
+			}
+			if !assert.Equal(t, "world", m["hello"]) {
+				return
+			}
+		})
+	}
+}
 
 func TestApp(t *testing.T) {
 	t.Run("will return OpenAPI spec", func(t *testing.T) {
@@ -39,35 +332,26 @@ func TestApp(t *testing.T) {
 				},
 			)
 
+			respCh := make(chan *http.Response, 1)
 			ctx, cancel := context.WithCancel(context.Background())
-
 			eg, egctx := errgroup.WithContext(ctx)
 			eg.Go(func() error {
 				return app.Run(egctx)
 			})
 			eg.Go(func() error {
 				defer cancel()
+				defer close(respCh)
 
 				addr := <-addrCh
 				resp, err := http.Get(fmt.Sprintf("http://%s/openapi.json", addr))
 				if err != nil {
 					return err
 				}
-				defer resp.Body.Close()
 
-				b, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-
-				var spec openapi3.Spec
-				err = json.Unmarshal(b, &spec)
-				if err != nil {
-					return err
-				}
-
-				if spec.Openapi != "3.0.3" {
-					return errors.New("incorrect version")
+				select {
+				case <-egctx.Done():
+					return egctx.Err()
+				case respCh <- resp:
 				}
 				return nil
 			})
@@ -76,26 +360,32 @@ func TestApp(t *testing.T) {
 			if !assert.Nil(t, err) {
 				return
 			}
+
+			resp := <-respCh
+			if !assert.NotNil(t, resp) {
+				return
+			}
+			defer resp.Body.Close()
+
+			b, err := io.ReadAll(resp.Body)
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			var spec openapi3.Spec
+			err = json.Unmarshal(b, &spec)
+			if !assert.Nil(t, err) {
+				return
+			}
+			if !assert.Equal(t, "3.0.3", spec.Openapi) {
+				return
+			}
 		})
 	})
 }
 
 func TestApp_Run(t *testing.T) {
 	t.Run("will return an error", func(t *testing.T) {
-		t.Run("if it fails to marshal the OpenAPI spec to JSON", func(t *testing.T) {
-			app := NewApp()
-
-			marshalErr := errors.New("failed to marshal")
-			app.marshalJSON = func(a any) ([]byte, error) {
-				return nil, marshalErr
-			}
-
-			err := app.Run(context.Background())
-			if !assert.ErrorIs(t, err, marshalErr) {
-				return
-			}
-		})
-
 		t.Run("if it fails to create a listener", func(t *testing.T) {
 			app := NewApp()
 


### PR DESCRIPTION
Closes #285 